### PR TITLE
Disabled placing MoneyPouches from off-hand.

### DIFF
--- a/src/main/java/com/leonardobishop/moneypouch/MoneyPouch.java
+++ b/src/main/java/com/leonardobishop/moneypouch/MoneyPouch.java
@@ -10,6 +10,7 @@ import com.leonardobishop.moneypouch.economytype.LemonMobCoinsEconomyType;
 import com.leonardobishop.moneypouch.economytype.VaultEconomyType;
 import com.leonardobishop.moneypouch.economytype.XPEconomyType;
 import com.leonardobishop.moneypouch.events.UseEvent;
+import com.leonardobishop.moneypouch.events.UseEvent_1_9_Plus;
 import com.leonardobishop.moneypouch.gui.MenuController;
 import com.leonardobishop.moneypouch.itemgetter.ItemGetter;
 import com.leonardobishop.moneypouch.itemgetter.ItemGetterLatest;
@@ -195,7 +196,7 @@ public class MoneyPouch extends JavaPlugin {
         super.getServer().getPluginCommand("moneypouch").setExecutor(new MoneyPouchBaseCommand(this));
         super.getServer().getPluginCommand("moneypouchshop").setExecutor(new MoneyPouchShopCommand(this));
         super.getServer().getPluginCommand("moneypouchadmin").setExecutor(new MoneyPouchAdminCommand(this));
-        super.getServer().getPluginManager().registerEvents(new UseEvent(this), this);
+
         super.getServer().getPluginManager().registerEvents(menuController, this);
 
         Bukkit.getScheduler().runTask(this, this::reload);
@@ -237,6 +238,12 @@ public class MoneyPouch extends JavaPlugin {
             titleHandle = new Title_BukkitReflect(this);
         } else {
             titleHandle = new Title_Bukkit();
+        }
+
+        if (version.startsWith("v1_7") || version.startsWith("v1_8")) {
+            super.getServer().getPluginManager().registerEvents(new UseEvent(this), this);
+        } else {
+            super.getServer().getPluginManager().registerEvents(new UseEvent_1_9_Plus(this), this);
         }
     }
 

--- a/src/main/java/com/leonardobishop/moneypouch/MoneyPouch.java
+++ b/src/main/java/com/leonardobishop/moneypouch/MoneyPouch.java
@@ -10,7 +10,7 @@ import com.leonardobishop.moneypouch.economytype.LemonMobCoinsEconomyType;
 import com.leonardobishop.moneypouch.economytype.VaultEconomyType;
 import com.leonardobishop.moneypouch.economytype.XPEconomyType;
 import com.leonardobishop.moneypouch.events.UseEvent;
-import com.leonardobishop.moneypouch.events.UseEvent_1_9_Plus;
+import com.leonardobishop.moneypouch.events.UseEventLatest;
 import com.leonardobishop.moneypouch.gui.MenuController;
 import com.leonardobishop.moneypouch.itemgetter.ItemGetter;
 import com.leonardobishop.moneypouch.itemgetter.ItemGetterLatest;
@@ -243,7 +243,7 @@ public class MoneyPouch extends JavaPlugin {
         if (version.startsWith("v1_7") || version.startsWith("v1_8")) {
             super.getServer().getPluginManager().registerEvents(new UseEvent(this), this);
         } else {
-            super.getServer().getPluginManager().registerEvents(new UseEvent_1_9_Plus(this), this);
+            super.getServer().getPluginManager().registerEvents(new UseEventLatest(this), this);
         }
     }
 

--- a/src/main/java/com/leonardobishop/moneypouch/events/UseEvent.java
+++ b/src/main/java/com/leonardobishop/moneypouch/events/UseEvent.java
@@ -23,8 +23,8 @@ import java.util.logging.Level;
 
 public class UseEvent implements Listener {
 
-    private final MoneyPouch plugin;
-    private final ArrayList<UUID> opening = new ArrayList<>();
+    protected final MoneyPouch plugin;
+    protected final ArrayList<UUID> opening = new ArrayList<>();
 
     public UseEvent(MoneyPouch plugin) {
         this.plugin = plugin;
@@ -72,13 +72,13 @@ public class UseEvent implements Listener {
         }
     }
 
-    private void playSound(Player player, String name) {
+    protected void playSound(Player player, String name) {
         try {
             player.playSound(player.getLocation(), Sound.valueOf(name), 3, 1);
         } catch (Exception ignored) { }
     }
 
-    private void usePouch(Player player, Pouch p) {
+    protected void usePouch(Player player, Pouch p) {
         opening.add(player.getUniqueId());
         long random = ThreadLocalRandom.current().nextLong(p.getMinRange(), p.getMaxRange());
         playSound(player, plugin.getConfig().getString("pouches.sound.opensound"));

--- a/src/main/java/com/leonardobishop/moneypouch/events/UseEventLatest.java
+++ b/src/main/java/com/leonardobishop/moneypouch/events/UseEventLatest.java
@@ -11,9 +11,9 @@ import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.EquipmentSlot;
 
 
-public class UseEvent_1_9_Plus extends UseEvent implements Listener {
+public class UseEventLatest extends UseEvent implements Listener {
 
-    public UseEvent_1_9_Plus(MoneyPouch plugin) {
+    public UseEventLatest(MoneyPouch plugin) {
         super(plugin);
     }
 
@@ -38,10 +38,8 @@ public class UseEvent_1_9_Plus extends UseEvent implements Listener {
                     }
 
                     if (opening.contains(player.getUniqueId())) {
-                        if (opening.contains(player.getUniqueId())) {
-                            player.sendMessage(plugin.getMessage(MoneyPouch.Message.ALREADY_OPENING));
-                            return;
-                        }
+                        player.sendMessage(plugin.getMessage(MoneyPouch.Message.ALREADY_OPENING));
+                        return;
                     }
 
                     String permission = "moneypouch.pouches." + p.getId();

--- a/src/main/java/com/leonardobishop/moneypouch/events/UseEvent_1_9_Plus.java
+++ b/src/main/java/com/leonardobishop/moneypouch/events/UseEvent_1_9_Plus.java
@@ -1,0 +1,72 @@
+package com.leonardobishop.moneypouch.events;
+
+import com.leonardobishop.moneypouch.MoneyPouch;
+import com.leonardobishop.moneypouch.Pouch;
+import com.leonardobishop.moneypouch.economytype.InvalidEconomyType;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.EquipmentSlot;
+
+
+public class UseEvent_1_9_Plus extends UseEvent implements Listener {
+
+    public UseEvent_1_9_Plus(MoneyPouch plugin) {
+        super(plugin);
+    }
+
+    @EventHandler
+    @Override
+    public void onPlayerUse(PlayerInteractEvent event) {
+        Player player = event.getPlayer();
+        if (event.getAction() != Action.RIGHT_CLICK_BLOCK && event.getAction() != Action.RIGHT_CLICK_AIR) {
+            return;
+        }
+
+        if (event.getHand() == EquipmentSlot.HAND) {
+            for (Pouch p : plugin.getPouches()) {
+                if (p.getItemStack().isSimilar(player.getInventory().getItemInMainHand())) {
+                    event.setCancelled(true);
+
+                    if (p.getEconomyType() instanceof InvalidEconomyType
+                            && plugin.getConfig().getBoolean("error-handling" +
+                            ".prevent-opening-invalid-pouches", true)) {
+                        player.sendMessage(plugin.getMessage(MoneyPouch.Message.INVALID_POUCH));
+                        return;
+                    }
+
+                    if (opening.contains(player.getUniqueId())) {
+                        if (opening.contains(player.getUniqueId())) {
+                            player.sendMessage(plugin.getMessage(MoneyPouch.Message.ALREADY_OPENING));
+                            return;
+                        }
+                    }
+
+                    String permission = "moneypouch.pouches." + p.getId();
+                    if (p.isPermissionRequired() && !player.hasPermission(permission)) {
+                        player.sendMessage(plugin.getMessage(MoneyPouch.Message.NO_PERMISSION));
+                        return;
+                    }
+
+                    if (player.getInventory().getItemInMainHand().getAmount() == 1) {
+                        player.getInventory().setItemInMainHand(null);
+                    } else {
+                        player.getInventory().getItemInMainHand().setAmount(player.getInventory().getItemInMainHand().getAmount() - 1);
+                        player.updateInventory();
+                    }
+
+                    super.usePouch(player, p);
+                }
+            }
+        } else {
+            for (Pouch p : super.plugin.getPouches()) {
+                if (p.getItemStack().isSimilar(player.getInventory().getItemInOffHand())) {
+                    event.setCancelled(true);
+                }
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
Fixes a bug where users could place the MoneyPouches when held in their off-hand, on server running version 1.9.x and higher.

We do this by cancelling the PlayerInteractEvent when it is called for the off-hand, and the item in the off-hand is a MoneyPouch. Tested on version 1.16.5

Solves #12